### PR TITLE
Set sell_cash column number to the same as sell_draft

### DIFF
--- a/lib/forex/traders/jm/jmmb.rb
+++ b/lib/forex/traders/jm/jmmb.rb
@@ -9,7 +9,7 @@ Forex::Trader.define "JMMB" do |t|
       currency_code: 0,
       buy_cash: 1,
       buy_draft: 3,
-      sell_cash: 2,
+      sell_cash: 4,
       sell_draft: 4
     }
 


### PR DESCRIPTION
JMMB doesn't put a sell_cash amount, they are considered to the be same
